### PR TITLE
multiple small improvements

### DIFF
--- a/WithRandomDelay/ext/background.js
+++ b/WithRandomDelay/ext/background.js
@@ -20,6 +20,10 @@ var extensionMode = "lax"; // lax or strict
 
 // name of storage vars
 var keys = ["excludeSite", "excludeOrigin", "ignoreSite", "ignoreOrigin", "mode"];
+
+// headers to be checked for observable difference
+var suspiciousHeaders = [ 'status', 'accept', 'content-encoding', 'content-range', 'content-length', 'host',  'etag' ];
+
 // map of user deciions for ignored requests.
 // ignored requests have the protection but user doesn't get notified
 var ignoreSiteMap = []; // based on URL Site
@@ -246,7 +250,7 @@ function onBeforeSendHeaders(details) {
 
     // condition 4: check if request contains cookies
     if(!headerExists(details, "Cookie")) {
-        console.log(details.requestId + " " + details.url + " no cookies!");
+        //console.log(details.requestId + " " + details.url + " no cookies!");
         // lacks root cause of leaky resource attacks
         //delete requestBody[details.requestId];
         return { requestHeaders: details.requestHeaders };
@@ -293,7 +297,7 @@ function onBeforeSendHeaders(details) {
             startsWith(tabUrl[details.tabId].toLowerCase(), "chrome://newtab/") == true ||
             startsWith(tabUrl[details.tabId].toLowerCase(), "chrome-extension://") == true ||
             startsWith(tabUrl[details.tabId].toLowerCase(), "edge://newtab/") == true) {
-                console.log(details.requestId + " " + details.url + " new tab!");
+                //console.log(details.requestId + " " + details.url + " new tab!");
             //delete requestBody[details.requestId];
             return { requestHeaders: details.requestHeaders };
         }
@@ -322,7 +326,7 @@ function onBeforeSendHeaders(details) {
             } else {
                 src = srctmp;
             }
-            console.log(details.requestId + " " + details.url + " related tabid:" + tabrelations[details.tabId][i] + " url: " + src);
+            //console.log(details.requestId + " " + details.url + " related tabid:" + tabrelations[details.tabId][i] + " url: " + src);
             sourceSite = getSiteFromUrl(src);
             sourceOrigin = combineOrigin(getOriginFromUrl(src));
             if(extensionMode == "lax") {
@@ -343,7 +347,7 @@ function onBeforeSendHeaders(details) {
     }
 
     if(!modeConditions) {
-        console.log(details.requestId + " " + details.url + " mode conditions false! src: " + src + " and the relations: " + tabrelations[details.tabId]);
+        //console.log(details.requestId + " " + details.url + " mode conditions false! src: " + src + " and the relations: " + tabrelations[details.tabId]);
         //delete requestBody[details.requestId];
         return { requestHeaders: details.requestHeaders };
     }
@@ -397,26 +401,30 @@ function onBeforeSendHeaders(details) {
  */
 function onHeadersReceived(details) {
     // check if it was marked as suspicious
-    if(corwc[details.requestId] && !occured[details.requestId]) {
+    if(corwc[details.requestId]) {
         // if there are multiple events fired for one requestId,
         // evaluate them only once (tracked with occured variable)
         // so corwc requests are evaluated only one time for
         // the distinguishable  differences
+        if(!occured[details.requestId]) {
+            // store response headers into memory for later use by @xhRequest
+            firstResponseHeaders[details.requestId] = [];
+            for(var i = 0, l = details.responseHeaders.length; i < l; i++) {
+                let hdr = details.responseHeaders[i].name.toLowerCase();
+                if(suspiciousHeaders.includes(hdr)) {
+                    firstResponseHeaders[details.requestId][hdr] = details.responseHeaders[i].value.toLowerCase();
+                }
+            }
 
-        // store response headers into memory for later use by @xhRequest
-        firstResponseHeaders[details.requestId] = [];
-        for(var i = 0, l = details.responseHeaders.length; i < l; i++) {
-            firstResponseHeaders[details.requestId][details.responseHeaders[i].name.toLowerCase()] = details.responseHeaders[i].value.toLowerCase();
+            //console.log(details.requestId + " going to xhr from " + xhrData[details.requestId].source + " to " + xhrData[details.requestId].target);
+            //susCount++;
+            //console.log('suspicious # ' + susCount + ' from ' + xhrData[details.requestId].source);
+
+            // make the second request, with cookies
+            //xhRequest(firstResponseHeaders[details.requestId], xhrData[details.requestId]);
+            setTimeout(xhRequest, Math.random() * 1000, details.requestId);
+            //delete corwc[details.requestId];
         }
-
-        //console.log(details.requestId + " going to xhr from " + xhrData[details.requestId].source + " to " + xhrData[details.requestId].target);
-        //susCount++;
-        //console.log('suspicious # ' + susCount + ' from ' + xhrData[details.requestId].source);
-
-        // make the second request, with cookies
-        //xhRequest(firstResponseHeaders[details.requestId], xhrData[details.requestId]);
-        setTimeout(xhRequest, Math.random() * 1000, details.requestId);
-        //delete corwc[details.requestId];
         // return response to first request, with Set-Cookie header removed
         return { responseHeaders: removeResponseHeaders(details, 'Set-Cookie') };
     }

--- a/WithRandomDelay/ext/options.js
+++ b/WithRandomDelay/ext/options.js
@@ -128,9 +128,9 @@ function excludeRemoveListener() {
         for(let i = 0; i < excludeSelect.length; i++) {
             if(excludeSelect.options[i].selected) {
                 let opt = excludeSelect.options[i];
-                console.log("value before split: " + opt.text);
+                //console.log("value before split: " + opt.text);
                 let texts = opt.text.split(' => ');
-                console.log("splited values: " + texts[0] + " " + texts[1] + " " + texts[2]);
+                //console.log("splited values: " + texts[0] + " " + texts[1] + " " + texts[2]);
                 let element = [texts[0], texts[1]];
                 remove.push(element);
                 excludeSelect.options[i] = null;
@@ -140,7 +140,7 @@ function excludeRemoveListener() {
             return;
         
         for(let i = 0; i < remove.length; i++) {
-            console.log("request to remove: " + remove[i][0] + " to " + remove[i][1]);
+            //console.log("request to remove: " + remove[i][0] + " to " + remove[i][1]);
             if(extMode == "lax") {
                 chrome.runtime.sendMessage({type: 'removeExcludeSite', source: remove[i][0], target: remove[i][1]}, null);
             } else {
@@ -184,9 +184,9 @@ function ignoreRemoveListener() {
         for(let i = 0; i < ignoreSelect.length; i++) {
             if(ignoreSelect.options[i].selected) {
                 let opt = ignoreSelect.options[i];
-                console.log("value before split: " + opt.text);
+                //console.log("value before split: " + opt.text);
                 let texts = opt.text.split(' => ');
-                console.log("splited values: " + texts[0] + " " + texts[1] + " " + texts[2]);
+                //console.log("splited values: " + texts[0] + " " + texts[1] + " " + texts[2]);
                 let element = [texts[0], texts[1]];
                 remove.push(element);
                 ignoreSelect.options[i] = null;
@@ -196,7 +196,7 @@ function ignoreRemoveListener() {
             return;
         
         for(let i = 0; i < remove.length; i++) {
-            console.log("request to remove: " + remove[i][0] + " to " + remove[i][1]);
+            //console.log("request to remove: " + remove[i][0] + " to " + remove[i][1]);
             if(extMode == "lax") {
                 chrome.runtime.sendMessage({type: 'removeIgnoreSite', source: remove[i][0], target: remove[i][1]}, null);
             } else {

--- a/WithRandomDelay/ext/popup.js
+++ b/WithRandomDelay/ext/popup.js
@@ -8,19 +8,19 @@ document.addEventListener('DOMContentLoaded', function () {
     chrome.runtime.sendMessage({type: "getMode"}, function(response) {
         if(response != undefined) {
             extMode = response.val;
-            console.log("mode: " + extMode);
+            //console.log("mode: " + extMode);
         }
     })
     chrome.runtime.sendMessage({type: "getSuspiciousList"}, function(response) {
-        console.log("message received in popup!");
+        //console.log("message received in popup!");
         if(response != undefined) {
             if(response.val != undefined) {
-                console.log("response size : " + response.val.length);
+                //console.log("response size : " + response.val.length);
                 createHtmlForSuspiciousList(response.val);
             }
         }
         else {
-            console.log("response size : 0");
+            //console.log("response size : 0");
         }
     });
     //var activeTabId;
@@ -107,7 +107,7 @@ function setHtmlForSuspiciousList(html, suspiciousMap) {
         let link = document.getElementById(idx+"_exclude");
         
             link.addEventListener('click', function() {
-                console.log("exclude clicked!");
+                //console.log("exclude clicked!");
                 if(extMode == "lax") {
                     chrome.runtime.sendMessage({type: 'excludeSite', source: src, target: trgt}, null);
                 } else {
@@ -120,7 +120,7 @@ function setHtmlForSuspiciousList(html, suspiciousMap) {
         link = document.getElementById(idx+"_excludeAll");
 
             link.addEventListener('click', function() {
-                console.log("excludeAll clicked!");
+                //console.log("excludeAll clicked!");
                 if(extMode == "lax") {
                     chrome.runtime.sendMessage({type: 'excludeSiteAll', target: trgt}, null);
                 } else {
@@ -132,7 +132,7 @@ function setHtmlForSuspiciousList(html, suspiciousMap) {
 
         link = document.getElementById(idx+"_ignore");
             link.addEventListener('click', function() {
-                console.log("ignore clicked!");
+                //console.log("ignore clicked!");
                 if(extMode == "lax") {
                     chrome.runtime.sendMessage({type: 'ignoreSite', source: src, target: trgt}, null);
                 } else {
@@ -145,7 +145,7 @@ function setHtmlForSuspiciousList(html, suspiciousMap) {
         link = document.getElementById(idx+"_ignoreAll");
         
             link.addEventListener('click', function() {
-                console.log("ignoreAll clicked!");
+                //console.log("ignoreAll clicked!");
                 if(extMode == "lax") {
                     chrome.runtime.sendMessage({type: 'ignoreSiteAll', target: trgt}, null);
                 } else {

--- a/WithRandomDelay/lib/utils.js
+++ b/WithRandomDelay/lib/utils.js
@@ -2,12 +2,11 @@
 
 // chrome doesn't allow extensions to set unsafe headers for a request
 // list of forbidden headers based on this spec: https://fetch.spec.whatwg.org/#forbidden-header-name
-var unsafeHeaders = [ 'Accept-Charset', 'Accept-Encoding', 'Access-Control-Request-Headers', 'Access-Control-Request-Method',
-                        'Connection', 'Content-Length', 'Cookie', 'Cookie2', 'Date', 'DNT', 'Expect', 'Host', 'Keep-Alive', 'Origin',
-                        'Referer', 'TE', 'Trailer', 'Transfer-Encoding', 'Upgrade', 'Via' , 'Proxy-', 'Sec-', 'User-Agent' ];
+var unsafeHeaders = [ 'accept-charset', 'accept-encoding', 'access-control-request-headers', 'access-control-request-method',
+                        'connection', 'content-length', 'cookie', 'cookie2', 'date', 'dnt', 'expect', 'host', 'keep-alive', 'origin',
+                        'referer', 'te', 'trailer', 'transfer-encoding', 'upgrade', 'via' , 'proxy-', 'sec-', 'user-agent' ];
 // User-Agent was not listed in ref page, but chrome doesn't allow it to be set by js.
 var unsafeHeadersStart = [ 'Proxy-', 'Sec-' ];
-
 
 function headerValue(array, key){
     for(let i = 0, l = array.length; i < l; i++)
@@ -20,17 +19,31 @@ function headerValue(array, key){
     return undefined;
 }
 function headerValue2(array, key){
-    let value = array.get(key);
+    /*let value = array.get(key);
     if(value != undefined && value != null)
     {
         return value.toLowerCase();
+    }*/
+    for (let hdr of array) {
+        if (hdr.name.toLowerCase() == key.toLowerCase()) {
+            if(hdr.value != undefined && hdr.value != null) {
+                return hdr.value.toLowerCase();
+            } else {
+                return undefined;
+            }
+        }
     }
     return undefined;
 }
 
 function headerExists(details, key){
-    for (let i = 0; i < details.requestHeaders.length; ++i) {
+    /*for (let i = 0; i < details.requestHeaders.length; ++i) {
         if (details.requestHeaders[i].name.toLowerCase() == key.toLowerCase()) {
+            return true;
+        }
+    }*/
+    for (let hdr of details.requestHeaders) {
+        if (hdr.name.toLowerCase() == key.toLowerCase()) {
             return true;
         }
     }
@@ -103,8 +116,13 @@ function startsWith(str1, str2) {
  */
 function returnHeaders(details) {
     let copiedHeaders = [];
-    for(let i = 0; i < details.requestHeaders.length; i++) {
+    /*for(let i = 0; i < details.requestHeaders.length; i++) {
         copiedHeaders.push(details.requestHeaders[i]);
+    }*/
+    for(let hdr of details.requestHeaders) {
+        if(!unsafeHeaders.includes(hdr.name.toLowerCase())) {
+            copiedHeaders.push(hdr);
+        }
     }
     return copiedHeaders
 }
@@ -118,23 +136,23 @@ function trimUnsafeHeaders(inputHeaders) {
     let trimmedHeaders = [];
     let flg = false;
     for (let i = 0; i < inputHeaders.length; ++i) {
-        for(let j = 0; j < unsafeHeaders.length; ++j) {
+        /*for(let j = 0; j < unsafeHeaders.length; ++j) {
             if(inputHeaders[i] != undefined) {
                 if (inputHeaders[i].name.toLowerCase() == unsafeHeaders[j].toLowerCase()) {
                     flg = true;
                     break;
                 }
             }
-        }
+        }*/
 
-        if(!flg) {
-            for(var j = 0; j < unsafeHeadersStart.length; ++j) {
-                if (startsWith(inputHeaders[i].name.toLowerCase(), unsafeHeadersStart[j].toLowerCase()) == true) {
-                    flg = true;
-                    break;
-                }
+        //if(!flg) {
+        for(var j = 0; j < unsafeHeadersStart.length; ++j) {
+            if (startsWith(inputHeaders[i].name.toLowerCase(), unsafeHeadersStart[j].toLowerCase()) == true) {
+                flg = true;
+                break;
             }
         }
+        //}
 
         if(!flg) {
             trimmedHeaders.push(inputHeaders[i]);


### PR DESCRIPTION
- Removing Set-Cookie response header from the response to login page request (response B) as well. It was neglected in a prior commit.
- When Leakuidator makes a second request with cookies (request A’) it sets all the request headers it recorded from the first request without cookies (request A), except the unsafe headers. The extension is not allowed to set those request headers. But, all request headers, including unsafe headers, were recorded earlier at the time of making the first request (request A). Now I changed the code to not record most of those unsafe headers, as they are not used.
- For response to the first request without cookies (response A), instead of recording all the response headers, only record the response headers that are used later to compare with response to the second request with cookies (response A’). It is not necessary to record all the response headers.
- Modified some utility functions that process the response headers or request headers, in hope of making them more efficient.
- Commenting out most of the console.log operations
